### PR TITLE
Add Rules to Limn

### DIFF
--- a/test/tech/thomascothran/limn/rules_test.clj
+++ b/test/tech/thomascothran/limn/rules_test.clj
@@ -1,0 +1,39 @@
+(ns tech.thomascothran.limn.rules-test
+  (:require [clojure.test :refer [deftest testing is]]
+            [tech.thomascothran.limn :as lm]
+            [tech.thomascothran.limn.adapters]))
+
+(def make-coffee-workflow
+  {:workflow/name "Make Coffee"
+   :workflow/actions
+   {:get-beans {:action/requires #{}
+                :action/produces #{:sufficient-coffee-beans}}
+    :grind {:action/requires #{:sufficient-coffee-beans}
+            :action/produces #{:ground-coffee}}
+    :brew {:action/requires #{:ground-coffee}
+           :action/produces #{:coffee}}
+    :pour {:action/requires #{:coffee}
+           :action/produces #{:coffee-cup}}}
+
+   :workflow/rules
+   {:sufficient-coffee-beans
+    {:fn '(fn [facts] (<= 3 (get facts :scoops)))}}})
+
+(deftest test-derivations-when-not-activated
+  (is (= #{:get-beans}
+         (-> (lm/make-workflow make-coffee-workflow)
+             (lm/add-facts {:scoops 2})
+             (lm/ready :actions))))
+
+  (is (= #{:grind}
+         (-> (lm/make-workflow make-coffee-workflow)
+             (lm/add-facts {:scoops 3})
+             (lm/ready :actions))))
+
+  (is (= #{:grind}
+         (-> make-coffee-workflow
+             (assoc-in [:workflow/actions :workflow/rules :sufficient-coffee-beans]
+                       (constantly true))
+             (lm/make-workflow)
+             (lm/add-facts {:scoops 3})
+             (lm/ready :actions)))))


### PR DESCRIPTION
Problem
-------
Often we have business rules that need to be converted to facts.

For example, if we are making coffee and need a minimum of three scoops, then we might need a fact `:sufficient-coffee-grounds`.

Solution
--------
Add a `workflow/rules` map of functions that can be applied to the facts to derive new facts.